### PR TITLE
chore: taskfileをdoppler用からinfisical用に変更

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,0 +1,5 @@
+{
+    "workspaceId": "acd2d3e5-bf15-46e9-8191-0b4f41049c98",
+    "defaultEnvironment": "",
+    "gitBranchToEnvironmentMapping": null
+}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,10 +4,10 @@ dotenv:
   - ".env"
 
 vars:
-  DOPPLER_CMD:
+  INFISICAL_CMD:
     sh: |
-      if command -v doppler >/dev/null 2>&1; then
-        echo "doppler run --"
+      if command -v infisical >/dev/null 2>&1; then
+        echo "infisical run --env=dev -- "
       else
         echo ""
       fi
@@ -34,10 +34,11 @@ tasks:
   # 全体操作コマンド
   # ----------------------------------------------------------------
   dev:
-    desc: 🚀 フロントとバックを同時に起動 (Doppler経由)
-    cmd: "{{.DOPPLER_CMD}} task dev:start"
+    desc: 🚀 フロントとバックを同時に起動 (Infisical経由)
+    cmd: "{{.INFISICAL_CMD}} task dev:start"
 
   dev:start:
+    internal: true
     deps:
       - task: backend:dev
       - task: frontend:dev
@@ -53,8 +54,18 @@ tasks:
   # ----------------------------------------------------------------
   up:
     desc: DBコンテナなどを起動
-    cmd: "{{.DOPPLER_CMD}} {{.COMPOSE_CMD}} up -d"
+    cmd: "{{.INFISICAL_CMD}} {{.COMPOSE_CMD}} up -d"
 
   down:
     desc: コンテナを停止
-    cmd: "{{.DOPPLER_CMD}} {{.COMPOSE_CMD}} down"
+    cmd: "{{.INFISICAL_CMD}} {{.COMPOSE_CMD}} down"
+
+  # ----------------------------------------------------------------
+  # 便利機能
+  # ----------------------------------------------------------------
+  sync:
+    desc: Infisical の値をローカルの .env に書き出し (エディタ用)
+    cmds:
+      - infisical export --env=dev --format=env > .env
+      - cd frontend && infisical export --env=dev --format=env > .env
+      - cd backend && infisical export --env=dev --format=env > .env

--- a/Taskfile/Taskfile.backend.yml
+++ b/Taskfile/Taskfile.backend.yml
@@ -1,5 +1,14 @@
 version: "3"
 
+vars:
+  INFISICAL_RUN:
+    sh: |
+      if [ -z "$INFISICAL_PROJECT_ID" ] && command -v infisical >/dev/null 2>&1; then
+        echo "infisical run --env=dev -- "
+      else
+        echo ""
+      fi
+
 tasks:
   install:
     desc: Python依存関係のインストール (uv)
@@ -9,9 +18,9 @@ tasks:
   dev:
     desc: FastAPIサーバーの起動
     cmds:
-      - uv run fastapi dev main.py
+      - "{{.INFISICAL_RUN}} uv run fastapi dev main.py"
 
   gen-types:
     desc: (内部用) サーバーを起動してOpenAPIを公開
     cmds:
-      - uv run fastapi dev main.py --port 8000
+      - "{{.INFISICAL_RUN}} uv run fastapi dev main.py --port 8000"

--- a/Taskfile/Taskfile.frontend.yml
+++ b/Taskfile/Taskfile.frontend.yml
@@ -1,5 +1,14 @@
 version: "3"
 
+vars:
+  INFISICAL_RUN:
+    sh: |
+      if [ -z "$INFISICAL_PROJECT_ID" ] && command -v infisical >/dev/null 2>&1; then
+        echo "infisical run --env=dev -- "
+      else
+        echo ""
+      fi
+
 tasks:
   default:
     desc: 利用可能なタスク一覧
@@ -11,22 +20,22 @@ tasks:
   dev:
     desc: 開発サーバー起動
     deps: [install]
-    cmd: pnpm dev
+    cmd: "{{.INFISICAL_RUN}} pnpm dev"
 
   build:
     desc: 本番ビルド
-    cmd: pnpm build
+    cmd: "{{.INFISICAL_RUN}} pnpm build"
 
   start:
     desc: 本番サーバー起動
-    cmd: pnpm start
+    cmd: "{{.INFISICAL_RUN}} pnpm start"
 
   install:
     desc: 依存関係のインストール
     cmd: pnpm install
 
   # ----------------------------------------------------------------
-  # ライブラリ管理 (前のプロジェクトの便利機能を継承)
+  # ライブラリ管理
   # ----------------------------------------------------------------
   add:
     desc: ライブラリを追加
@@ -48,7 +57,7 @@ tasks:
     cmd: pnpm biome check .
 
   check-w:
-    desc: Biomeによるチェック & 自動修正 (おすすめ)
+    desc: Biomeによるチェック & 自動修正
     cmd: pnpm biome check --write .
 
   format:
@@ -64,4 +73,4 @@ tasks:
   # ----------------------------------------------------------------
   gen-types:
     desc: バックエンド(FastAPI)からTypeScriptの型を自動生成
-    cmd: pnpm openapi-zod-client http://127.0.0.1:8000/openapi.json -o src/types/api.ts
+    cmd: "{{.INFISICAL_RUN}} pnpm openapi-zod-client http://127.0.0.1:8000/openapi.json -o src/types/api.ts"


### PR DESCRIPTION
chore: taskfileをdoppler用からinfisical用に変更

Dopplerの無料枠（3名まで）の制限を回避し、現在の4人チームで継続して
シークレットを共有・管理するため、Infisical Cloud（5名まで無料）へ移行しました。

■ 変更内容
- DOPPLER_CMD を削除し、INFISICAL_CMD を導入
- `$INFISICAL_PROJECT_ID` による環境変数注入の二重起動防止ロジックを実装
  - これにより、`task dev`（一括起動）と `task frontend:dev`（個別起動）の
    どちらからでも、冗長な通信を避けつつ環境変数が正しく注入されます。
- `task sync` コマンドを追加
  - Infisical の値をローカルの `.env` に書き出せるようにしました。
  - Neovim 等のエディタ起動時にネットワーク通信を待つ必要がなくなります。
- Docker Compose 連携の修正
  - `task up` 時に Infisical を経由することで、`docker-compose.yml` 内で
    環境変数を安全に参照できるようになりました。

■ なぜ Infisical か
- Starterプラン (Cloud) において最大5名まで無料で利用可能。
- 豊富なインテグレーションにより、今後のデプロイフローにも柔軟に対応可能。