### PR TITLE
feat: implement a comprehensive history and versioning service for se…

### DIFF
--- a/backend/app/services/history_service.py
+++ b/backend/app/services/history_service.py
@@ -1,0 +1,308 @@
+"""History service - 2-layer storage business logic.
+
+Phase 1 (Hot): Operation logs in hot_operations (72h TTL)
+Phase 2 (Cold): Snapshots in cold_snapshots (permanent)
+"""
+
+import difflib
+import json
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+from sqlalchemy import update as sa_update
+from sqlalchemy.orm import Session
+
+from app.models import HotOperation, ColdSnapshot, Section, User
+
+
+# TTL for hot operations (72 hours)
+HOT_OPERATION_TTL_HOURS = 72
+
+
+def record_operation(
+    db: Session,
+    section_id: UUID,
+    user_id: UUID,
+    operation_type: str,
+    payload: dict | None = None,
+) -> HotOperation:
+    """Record an operation in hot_operations and create a cold snapshot.
+
+    1. Increment section version (atomic SQL-level update)
+    2. Save operation log (Phase 1 - hot, 72h)
+    3. Save content snapshot (Phase 2 - cold, permanent)
+    """
+    section = db.query(Section).filter(Section.id == section_id).first()
+    if not section:
+        raise ValueError("Section not found")
+
+    # Validate user exists
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise ValueError("User not found")
+
+    # Atomic version increment at SQL level (no row lock required)
+    db.execute(
+        sa_update(Section)
+        .where(Section.id == section_id)
+        .values(version=Section.version + 1)
+    )
+    db.flush()
+    db.refresh(section)
+    new_version = section.version
+
+    # Phase 1: Record hot operation
+    operation = HotOperation(
+        section_id=section_id,
+        operation_type=operation_type,
+        payload=payload,
+        user_id=user_id,
+        version=new_version,
+    )
+    db.add(operation)
+
+    # Phase 2: Create cold snapshot of current content
+    snapshot = ColdSnapshot(
+        section_id=section_id,
+        content=section.content,
+        version=new_version,
+    )
+    db.add(snapshot)
+
+    db.commit()
+    db.refresh(operation)
+    return operation
+
+
+def get_history(
+    db: Session,
+    section_id: UUID,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[dict], int]:
+    """Get operation history for a section (72h window only).
+
+    Returns list of history items with user info, and total count.
+    Uses JOIN to avoid N+1 query problem.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=HOT_OPERATION_TTL_HOURS)
+
+    query = (
+        db.query(HotOperation)
+        .filter(
+            HotOperation.section_id == section_id,
+            HotOperation.created_at >= cutoff,
+        )
+        .order_by(HotOperation.created_at.desc())
+    )
+
+    total = query.count()
+    operations = query.offset(offset).limit(limit).all()
+
+    # Batch-load user data: collect unique user_ids and query once
+    user_ids = {op.user_id for op in operations}
+    users = db.query(User).filter(User.id.in_(user_ids)).all()
+    user_map = {u.id: u for u in users}
+
+    items = []
+    for op in operations:
+        user = user_map.get(op.user_id)
+        items.append(
+            {
+                "id": op.id,
+                "section_id": op.section_id,
+                "operation_type": op.operation_type,
+                "payload": op.payload,
+                "user": {
+                    "id": user.id,
+                    "displayName": user.display_name,
+                    "avatarUrl": user.avatar_url,
+                }
+                if user
+                else None,
+                "version": op.version,
+                "created_at": op.created_at,
+            }
+        )
+
+    return items, total
+
+
+def rollback_to_version(
+    db: Session,
+    section_id: UUID,
+    version: int,
+    user_id: UUID | None = None,
+) -> Section:
+    """Rollback a section to a specific version.
+
+    Only allowed if version is within the 72h hot operation window.
+    Version always increments forward (content is restored, not the version number).
+    The rollback operation itself is recorded in history.
+    """
+    section = db.query(Section).filter(Section.id == section_id).first()
+    if not section:
+        raise ValueError("Section not found")
+
+    # Check the operation at that version is within 72h
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=HOT_OPERATION_TTL_HOURS)
+    operation = (
+        db.query(HotOperation)
+        .filter(
+            HotOperation.section_id == section_id,
+            HotOperation.version == version,
+            HotOperation.created_at >= cutoff,
+        )
+        .first()
+    )
+
+    if not operation:
+        raise ValueError("Version not found or outside 72-hour rollback window")
+
+    # Get the cold snapshot for the target version
+    snapshot = (
+        db.query(ColdSnapshot)
+        .filter(
+            ColdSnapshot.section_id == section_id,
+            ColdSnapshot.version == version,
+        )
+        .first()
+    )
+
+    if not snapshot:
+        raise ValueError("Snapshot not found for this version")
+
+    # Restore content from snapshot, but increment version forward (never go backwards)
+    db.execute(
+        sa_update(Section)
+        .where(Section.id == section_id)
+        .values(version=Section.version + 1, content=snapshot.content)
+    )
+    db.flush()
+    db.refresh(section)
+
+    # Record the rollback as an operation so history is not broken
+    rollback_op = HotOperation(
+        section_id=section_id,
+        operation_type="rollback",
+        payload={"restored_version": version},
+        user_id=user_id or operation.user_id,
+        version=section.version,
+    )
+    db.add(rollback_op)
+
+    rollback_snapshot = ColdSnapshot(
+        section_id=section_id,
+        content=section.content,
+        version=section.version,
+    )
+    db.add(rollback_snapshot)
+
+    db.commit()
+    db.refresh(section)
+    return section
+
+
+def get_diff(
+    db: Session,
+    section_id: UUID,
+    from_version: int,
+    to_version: int,
+) -> dict:
+    """Compute diff between two snapshot versions.
+
+    Uses difflib for line-level unified diff comparison.
+    """
+    from_snapshot = (
+        db.query(ColdSnapshot)
+        .filter(
+            ColdSnapshot.section_id == section_id,
+            ColdSnapshot.version == from_version,
+        )
+        .first()
+    )
+
+    to_snapshot = (
+        db.query(ColdSnapshot)
+        .filter(
+            ColdSnapshot.section_id == section_id,
+            ColdSnapshot.version == to_version,
+        )
+        .first()
+    )
+
+    if not from_snapshot or not to_snapshot:
+        raise ValueError("Snapshot not found for one or both versions")
+
+    # Extract text content from Tiptap JSON
+    from_text = _extract_text(from_snapshot.content)
+    to_text = _extract_text(to_snapshot.content)
+
+    additions, deletions = _compute_diff(from_text, to_text)
+
+    return {
+        "from_version": from_version,
+        "to_version": to_version,
+        "additions": additions,
+        "deletions": deletions,
+    }
+
+
+def _extract_text(content: dict | None) -> str:
+    """Extract plain text from Tiptap JSON content.
+
+    Recursively walks the Tiptap document tree and extracts text nodes.
+    Falls back to json.dumps if the structure is unrecognized.
+    """
+    if not content:
+        return ""
+
+    texts: list[str] = []
+
+    def _walk(node: dict | list) -> None:
+        if isinstance(node, list):
+            for item in node:
+                _walk(item)
+            return
+        if not isinstance(node, dict):
+            return
+        # Tiptap text nodes have a "text" field
+        if "text" in node:
+            texts.append(node["text"])
+        # Recurse into "content" array (Tiptap block structure)
+        if "content" in node:
+            _walk(node["content"])
+
+    _walk(content)
+
+    if texts:
+        return "\n".join(texts)
+    # Fallback: serialize as JSON for non-Tiptap content
+    return json.dumps(content, ensure_ascii=False, sort_keys=True)
+
+
+def _compute_diff(from_text: str, to_text: str) -> tuple[list[dict], list[dict]]:
+    """Compute line-level diff between two strings using difflib.
+
+    Returns (additions, deletions) where each item has line number and text.
+    """
+    additions: list[dict] = []
+    deletions: list[dict] = []
+
+    if from_text == to_text:
+        return additions, deletions
+
+    from_lines = from_text.splitlines(keepends=True)
+    to_lines = to_text.splitlines(keepends=True)
+
+    for tag, i1, i2, j1, j2 in difflib.SequenceMatcher(
+        None, from_lines, to_lines
+    ).get_opcodes():
+        if tag in ("delete", "replace"):
+            for idx in range(i1, i2):
+                deletions.append({"start": idx, "end": idx + 1, "text": from_lines[idx].rstrip("\n")})
+        if tag in ("insert", "replace"):
+            for idx in range(j1, j2):
+                additions.append({"start": idx, "end": idx + 1, "text": to_lines[idx].rstrip("\n")})
+
+    return additions, deletions


### PR DESCRIPTION
# history_service.py 修正内容

## 修正一覧

| # | 修正内容 | 重要度 | 同時編集への影響 |
|---|---|---|---|
| 1 | N+1クエリ修正 | 高 | なし |
| 2 | バージョンのアトミックインクリメント | 高 | なし（ロック不使用） |
| 3 | ロールバック時のバージョン戦略 | 高 | なし |
| 4 | ロールバック操作の記録 | 中 | なし |
| 5 | `_simple_diff()` → `_compute_diff()` 改善 | 中 | なし |
| 6 | `_extract_text()` を実テキスト抽出に修正 | 中 | なし |
| 7 | `get_history()` の無駄な JOIN 削除 | 中 | なし |
| 8 | `_compute_diff()` 戻り値のスキーマ修正 | 高 | なし |
| 9 | 未使用 import 削除 | 低 | なし |

---

### 修正1: N+1クエリ修正（`get_history()`）

**問題**: ループ内で毎回 `User` を個別クエリしていた（操作50件 → 50回のDBアクセス）

```diff
-    for op in operations:
-        user = db.query(User).filter(User.id == op.user_id).first()
+    # ユーザーIDを集めて1回のクエリで一括取得
+    user_ids = {op.user_id for op in operations}
+    users = db.query(User).filter(User.id.in_(user_ids)).all()
+    user_map = {u.id: u for u in users}
+
+    for op in operations:
+        user = user_map.get(op.user_id)
```

---

### 修正2: バージョンのアトミックインクリメント（`record_operation()`）

**問題**: Pythonレベルの `version += 1` は同時アクセスで競合する

```diff
-    section.version += 1
-    new_version = section.version
+    # SQLレベルでアトミックにインクリメント（ロック不要）
+    db.execute(
+        sa_update(Section)
+        .where(Section.id == section_id)
+        .values(version=Section.version + 1)
+    )
+    db.flush()
+    db.refresh(section)
+    new_version = section.version
```

> [!IMPORTANT]
> `with_for_update()`（悲観的ロック）ではなく SQLレベルの `SET version = version + 1` を使用。
> これにより行ロックが発生せず、Yjs による同時編集に影響しない。

---

### 修正3: ロールバック時のバージョン戦略（`rollback_to_version()`）

**問題**: `section.version = version` でバージョンが過去に戻り、将来の操作でバージョン番号が重複する

```diff
-    section.content = snapshot.content
-    section.version = version
+    # バージョンは常に前進、内容だけ復元
+    db.execute(
+        sa_update(Section)
+        .where(Section.id == section_id)
+        .values(version=Section.version + 1, content=snapshot.content)
+    )
```

---

### 修正4: ロールバック操作の記録（`rollback_to_version()`）

**問題**: ロールバック自体が履歴に残らず、履歴が途切れていた

```diff
+    # ロールバック操作を HotOperation と ColdSnapshot に記録
+    rollback_op = HotOperation(
+        section_id=section_id,
+        operation_type="rollback",
+        payload={"restored_version": version},
+        user_id=user_id or operation.user_id,
+        version=section.version,
+    )
+    db.add(rollback_op)
+
+    rollback_snapshot = ColdSnapshot(
+        section_id=section_id,
+        content=section.content,
+        version=section.version,
+    )
+    db.add(rollback_snapshot)
```

> [!NOTE]
> `rollback_to_version()` に `user_id` 引数を追加（誰がロールバックしたかを記録）。

---

### 修正5: diff 改善（`_simple_diff()` → `_compute_diff()`）

**問題**: テキストが異なれば全文を丸ごと追加/削除として返すだけだった

```diff
-def _simple_diff(from_text, to_text):
-    # テキストが違えば全文を返すだけ
-    if from_text != to_text:
-        deletions.append({"start": 0, "end": len(from_text), "text": from_text})
-        additions.append({"start": 0, "end": len(to_text), "text": to_text})
+def _compute_diff(from_text, to_text):
+    # difflib.SequenceMatcher で行単位の差分を計算
+    for tag, i1, i2, j1, j2 in difflib.SequenceMatcher(
+        None, from_lines, to_lines
+    ).get_opcodes():
+        if tag in ("delete", "replace"):
+            deletions.append({"line": idx + 1, "text": ...})
+        if tag in ("insert", "replace"):
+            additions.append({"line": idx + 1, "text": ...})
```

---

### 修正6: `_extract_text()` をTiptap対応に修正

**問題**: `json.dumps()` するだけで、Tiptap JSONからテキストを抽出していなかった

```diff
-def _extract_text(content):
-    return json.dumps(content, ensure_ascii=False, sort_keys=True)
+def _extract_text(content):
+    # Tiptap JSONツリーを再帰的に走査し、textノードを抽出
+    def _walk(node):
+        if "text" in node:
+            texts.append(node["text"])
+        if "content" in node:
+            _walk(node["content"])
+    _walk(content)
+    return "\n".join(texts) if texts else json.dumps(...)
```

---

### 追加: `user_id` バリデーション（`record_operation()`）

存在しないユーザーIDが渡されたときの事前チェックを追加。

```diff
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise ValueError("User not found")
```

---

### 修正7: `get_history()` の無駄な JOIN 削除

**問題**: `.join(User, ...)` しているが `db.query(HotOperation)` では User データが取得されず、クエリを重くしているだけだった。ユーザーデータは下の batch load で別途取得済み。

```diff
     query = (
         db.query(HotOperation)
-        .join(User, HotOperation.user_id == User.id, isouter=True)
         .filter(
             HotOperation.section_id == section_id,
             HotOperation.created_at >= cutoff,
         )
         .order_by(HotOperation.created_at.desc())
     )
```

> [!NOTE]
> batch load（`User.id.in_(user_ids)`）は残しているため、ユーザー情報の取得には影響なし。

---

### 修正8: `_compute_diff()` 戻り値のスキーマ修正

**問題**: `_compute_diff()` が `{"line", "text"}` を返していたが、`DiffChange` スキーマは `{"start", "end", "text"}` を要求。これにより diff エンドポイントが **Pydantic ValidationError（500エラー）** になっていた。

```diff
         if tag in ("delete", "replace"):
             for idx in range(i1, i2):
-                deletions.append({"line": idx + 1, "text": from_lines[idx].rstrip("\n")})
+                deletions.append({"start": idx, "end": idx + 1, "text": from_lines[idx].rstrip("\n")})
         if tag in ("insert", "replace"):
             for idx in range(j1, j2):
-                additions.append({"line": idx + 1, "text": to_lines[idx].rstrip("\n")})
+                additions.append({"start": idx, "end": idx + 1, "text": to_lines[idx].rstrip("\n")})
```

> [!IMPORTANT]
> この修正が無いと `GET /sections/{id}/diff/{from}/{to}` が本番でも500エラーになる。

---

### 修正9: 未使用 import 削除

**問題**: 修正7で JOIN を削除したため、`joinedload` が未使用になっていた。

```diff
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session
```
