### PR TITLE
fix: 改行文字が異なる問題を.gitattributeと.editorconfigによって改善(絶対に対策できるわけではない)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+[*]
+end_of_line = lf
+charset = utf-8
+[*.py]
+indent_size = 4
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# テキストファイルの改行をLFに正規化（git利用者向け）
+* text=auto eol=lf
+# バイナリファイル（改行変換しない）
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary


### PR DESCRIPTION
2ファイル追加

.gitattributes
テキストファイルの改行をLFに正規化（git利用者向け）

.editorconfig
ルールの記述

フォーマッター等を活用して、改行文字をLFに統一してください。出ないとマージするときに本当に痛い目を見ます。