### PR TITLE
fix(sns): ensure fork sends empty json object instead of undefined

### DIFF
--- a/frontend/src/lib/api/__tests__/snsRepository.test.ts
+++ b/frontend/src/lib/api/__tests__/snsRepository.test.ts
@@ -145,7 +145,7 @@ describe("snsRepository", () => {
       await snsRepository.fork("plot-001", undefined, "test-token");
 
       const request = fetchMock.mock.calls[0][1];
-      expect(request.body).toBeUndefined();
+      expect(request.body).toBe("{}");
     });
 
     it("should throw ApiError(404) for plot-404", async () => {

--- a/frontend/src/lib/api/repositories/snsRepository.ts
+++ b/frontend/src/lib/api/repositories/snsRepository.ts
@@ -63,7 +63,7 @@ export async function fork(
   }
   return apiClient<PlotResponse>(`/plots/${plotId}/fork`, {
     method: "POST",
-    body,
+    body: body ?? {},
     token,
   });
 }


### PR DESCRIPTION
## 発生していた問題の原因
もともとの実装では、フロントエンドの `ForkButton.tsx` から `snsRepository.fork(plotId, undefined)` が呼び出されており、それが `apiClient` に渡された結果、**HTTPのボディ自体が存在しない（空文字列すら送られない）リクエスト**になっていました。

しかし、バックエンド（FastAPI）の定義では以下のように定められています：

```python
class ForkRequest(BaseModel):
    title: str | None = None

def fork_plot(plot_id: UUID, body: ForkRequest, ...):
```

「`body` は `ForkRequest` というJSONオブジェクトである」という制約があるため、JSONの体裁をなしていない（空っぽの）リクエストが来ると、FastAPI（Pydantic）が「JSON形式ではない」と判断し、`422` エラーで弾いてしまうのが根本的な原因でした。

## 修正内容

### 1. リクエストボディに空のJSON `{}` を明示的に渡すように修正
フロントエンドからバックエンドへリクエストを送る際、「空のJSON（`{}`）」を明示的に送るように `snsRepository.ts` を修正しました。

```typescript
// frontend/src/lib/api/repositories/snsRepository.ts
export async function fork(
    plotId: string,
    body?: ForkPlotRequest,
    token?: string,
  ): Promise<PlotResponse> {
    // ...
    return apiClient<PlotResponse>(`/plots/${plotId}/fork`, {
      method: "POST",
-     body,             // 修正前: タイトル未入力だと未定義(undefined)が送られ弾かれる
+     body: body ?? {}, // 修正後: タイトル未入力でも空のJSON `{}` を送る
      token,
    });
  }
```

これにより、FastAPI側でも `"title" が無いだけの正当な JSON object` として受理されるようになりました。

### 2. テストコードの期待値を `{}` に更新
本体コードの変更に合わせ、リクエストボディが適切に `{}` として送られていることを検証するように、テストコードの判定基準も合わせて修正しました。

```typescript
// frontend/src/lib/api/__tests__/snsRepository.test.ts
it("should work with empty body", async () => {
      // ...
      await snsRepository.fork("plot-001", undefined, "test-token");
      const request = fetchMock.mock.calls[0][1];
      
-     expect(request.body).toBeUndefined(); // 修正前
+     expect(request.body).toBe("{}");        // 修正後
    });
```

この2点の修正で、タイトルを付与しなくても正常にフォーク機能が動作することを確認しています！
ご確認のほどよろしくお願いいたします。
