### PR TITLE
fix: からセクションの表示

### DIFF
--- a/frontend/src/components/section/SectionList/__tests__/SectionList.test.tsx
+++ b/frontend/src/components/section/SectionList/__tests__/SectionList.test.tsx
@@ -53,7 +53,7 @@ describe("SectionList", () => {
     expect(container.querySelector("h2")).toBeNull();
   });
 
-  it("content が null のセクションは表示されない", () => {
+  it("content が null のセクションでもタイトルは表示される", () => {
     const sectionsWithNull: SectionResponse[] = [
       {
         ...mockSections[0],
@@ -63,6 +63,6 @@ describe("SectionList", () => {
 
     render(<SectionList sections={sectionsWithNull} />);
 
-    expect(screen.queryByRole("heading", { level: 2 })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("仕様");
   });
 });

--- a/frontend/src/components/section/SectionViewer/SectionViewer.tsx
+++ b/frontend/src/components/section/SectionViewer/SectionViewer.tsx
@@ -20,14 +20,12 @@ export function SectionViewer({
   const editor = useEditor(
     {
       extensions: [StarterKit],
-      content: section.content,
+      content: section.content ?? undefined,
       editable: false,
       immediatelyRender: false,
     },
     [section.content, section.version],
   );
-
-  if (!section.content) return null;
 
   return (
     <div id={`section-${section.id}`} className={styles.container}>
@@ -35,9 +33,11 @@ export function SectionViewer({
         <h2 className={styles.title}>{section.title}</h2>
         {isBeingEdited && <SectionLockBadge lockedBy={editedBy} />}
       </div>
-      <div className={styles.content}>
-        <EditorContent editor={editor} />
-      </div>
+      {section.content && (
+        <div className={styles.content}>
+          <EditorContent editor={editor} />
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/section/SectionViewer/__tests__/SectionViewer.test.tsx
+++ b/frontend/src/components/section/SectionViewer/__tests__/SectionViewer.test.tsx
@@ -37,10 +37,11 @@ describe("SectionViewer", () => {
     expect(screen.getByTestId("editor-content")).toBeInTheDocument();
   });
 
-  it("content が null の場合、何も表示されない", () => {
-    const { container } = render(<SectionViewer section={sectionWithoutContent} />);
+  it("content が null の場合、タイトルのみ表示される", () => {
+    render(<SectionViewer section={sectionWithoutContent} />);
 
-    expect(container.firstChild).toBeNull();
+    expect(screen.getByText("空セクション")).toBeInTheDocument();
+    expect(screen.queryByTestId("editor-content")).not.toBeInTheDocument();
   });
 
   it("isBeingEdited が true の場合、SectionLockBadge が表示される", () => {


### PR DESCRIPTION
現在タイトルだけでセクションが体と表示されなかったがセクションの中身画からでもタイトルだけが表示されるようにした