### PR TITLE
fix: starが再読込したら消える問題を修正

### DIFF
--- a/frontend/src/app/plots/[id]/__tests__/page.test.tsx
+++ b/frontend/src/app/plots/[id]/__tests__/page.test.tsx
@@ -7,6 +7,16 @@ vi.mock("@/lib/api/repositories/plotRepository", () => ({
   get: vi.fn(),
 }));
 
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: {
+      getSession: vi.fn(async () => ({
+        data: { session: { access_token: "test-access-token" } },
+      })),
+    },
+  })),
+}));
+
 vi.mock("next/navigation", () => ({
   notFound: vi.fn(),
   useRouter: () => ({ push: vi.fn() }),
@@ -79,7 +89,7 @@ describe("PlotDetailPage", () => {
     render(page);
 
     expect(screen.getByText("テスト Plot")).toBeInTheDocument();
-    expect(plotRepository.get).toHaveBeenCalledWith("plot-001");
+    expect(plotRepository.get).toHaveBeenCalledWith("plot-001", "test-access-token");
   });
 
   it("404エラーの場合 notFound() が呼ばれる", async () => {
@@ -109,6 +119,6 @@ describe("PlotDetailPage", () => {
       params: Promise.resolve({ id: "plot-002" }),
     });
 
-    expect(plotRepository.get).toHaveBeenCalledWith("plot-002");
+    expect(plotRepository.get).toHaveBeenCalledWith("plot-002", "test-access-token");
   });
 });

--- a/frontend/src/app/plots/[id]/page.tsx
+++ b/frontend/src/app/plots/[id]/page.tsx
@@ -2,13 +2,19 @@ import { notFound } from "next/navigation";
 import { PlotDetail } from "@/components/plot/PlotDetail/PlotDetail";
 import { ApiError } from "@/lib/api/client";
 import * as plotRepository from "@/lib/api/repositories/plotRepository";
+import { createClient } from "@/lib/supabase/server";
 import styles from "./page.module.scss";
 
 export default async function PlotDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
 
   try {
-    const plot = await plotRepository.get(id);
+    const supabase = await createClient();
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    const plot = await plotRepository.get(id, session?.access_token);
     return (
       <div className={styles.page}>
         <PlotDetail plot={plot} />

--- a/frontend/src/components/plot/PlotCard/PlotCard.module.scss
+++ b/frontend/src/components/plot/PlotCard/PlotCard.module.scss
@@ -69,6 +69,14 @@
     gap: 0.25rem;
 }
 
+.starIcon {
+    transition: color 0.2s ease;
+}
+
+.starred {
+    color: hsl(var(--chart-5));
+}
+
 .date {
     white-space: nowrap;
 }

--- a/frontend/src/components/plot/PlotCard/PlotCard.tsx
+++ b/frontend/src/components/plot/PlotCard/PlotCard.tsx
@@ -46,7 +46,13 @@ export function PlotCard({ plot }: PlotCardProps) {
 
         <CardFooter className={styles.footer}>
           <Badge variant="secondary" className={cn(styles.stars)}>
-            <Star size={14} />
+            <Star
+              size={14}
+              fill={plot.isStarred ? "currentColor" : "none"}
+              className={cn(styles.starIcon, {
+                [styles.starred]: plot.isStarred,
+              })}
+            />
             {plot.starCount}
           </Badge>
           <time dateTime={plot.createdAt} className={styles.date}>

--- a/frontend/src/components/plot/PlotCard/__tests__/PlotCard.test.tsx
+++ b/frontend/src/components/plot/PlotCard/__tests__/PlotCard.test.tsx
@@ -64,6 +64,25 @@ describe("PlotCard", () => {
     expect(starBadge?.querySelector("svg")).toBeTruthy();
   });
 
+  it("isStarred=true のときスターアイコンが塗りつぶし表示になる", () => {
+    const starredPlot: PlotResponse = {
+      ...mockPlot,
+      isStarred: true,
+    };
+
+    const { container } = render(<PlotCard plot={starredPlot} />);
+    const starIcon = container.querySelector("svg");
+
+    expect(starIcon).toHaveAttribute("fill", "currentColor");
+  });
+
+  it("isStarred=false のときスターアイコンは塗りつぶされない", () => {
+    const { container } = render(<PlotCard plot={mockPlot} />);
+    const starIcon = container.querySelector("svg");
+
+    expect(starIcon).toHaveAttribute("fill", "none");
+  });
+
   it("リンク先が正しい (/plots/{id})", () => {
     render(<PlotCard plot={mockPlot} />);
     const links = screen.getAllByRole("link");

--- a/frontend/src/hooks/useStar.ts
+++ b/frontend/src/hooks/useStar.ts
@@ -41,6 +41,7 @@ export function useStar(plotId: string, initialCount: number, initialIsStarred: 
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.stars.byPlot(plotId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.plots.all });
     },
   });
 


### PR DESCRIPTION
現在starを再読込した場合押したstarが見えなくなるがそこでもう一度押すと409エラーが返ってくる。つまり、描画上の問題ちゃんとstar押したかどうかの判定をページ読み込み時に追加