### PR TITLE
fix: ログインしていないときにも編集ボタンを表示(ログインページに飛ばされる)

### DIFF
--- a/frontend/src/components/section/SectionEditor/SectionEditor.tsx
+++ b/frontend/src/components/section/SectionEditor/SectionEditor.tsx
@@ -258,7 +258,7 @@ export function SectionEditor({
                 {onDelete && (
                   <Button
                     variant="destructive"
-                    size="icon"
+                    size="sm"
                     onClick={() => setDeleteDialogOpen(true)}
                     disabled={isDeleting}
                     aria-label="削除"

--- a/frontend/src/components/section/SectionList/__tests__/SectionList.test.tsx
+++ b/frontend/src/components/section/SectionList/__tests__/SectionList.test.tsx
@@ -61,7 +61,7 @@ describe("SectionList", () => {
     expect(container.querySelector("h2")).toBeNull();
   });
 
-  it("content が null のセクションは表示されない", () => {
+  it("content が null のセクションでもタイトルは表示される", () => {
     const sectionsWithNull: SectionResponse[] = [
       {
         ...mockSections[0],
@@ -71,7 +71,7 @@ describe("SectionList", () => {
 
     render(<SectionList sections={sectionsWithNull} />);
 
-    expect(screen.queryByRole("heading", { level: 2 })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "仕様" })).toBeInTheDocument();
   });
 
   it("connectionStatus が connected の場合、接続中インジケータが表示される", () => {

--- a/frontend/src/components/section/SectionViewer/SectionViewer.tsx
+++ b/frontend/src/components/section/SectionViewer/SectionViewer.tsx
@@ -38,8 +38,9 @@ export function SectionViewer({
     };
   }, [provider, section.id]);
 
-  const displayContent = liveContent ?? section.content;
-  if (!displayContent) return null;
+  const displayContent =
+    liveContent ??
+    ((section.content as Record<string, unknown> | null) ?? { type: "doc", content: [] });
 
   return (
     <div

--- a/frontend/src/components/section/SectionViewer/__tests__/SectionViewer.test.tsx
+++ b/frontend/src/components/section/SectionViewer/__tests__/SectionViewer.test.tsx
@@ -37,11 +37,11 @@ describe("SectionViewer", () => {
     expect(screen.getByTestId("editor-content")).toBeInTheDocument();
   });
 
-  it("content が null の場合、セクションは描画されない", () => {
+  it("content が null の場合でもセクションが描画される", () => {
     render(<SectionViewer section={sectionWithoutContent} />);
 
-    expect(screen.queryByText("空セクション")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("editor-content")).not.toBeInTheDocument();
+    expect(screen.getByText("空セクション")).toBeInTheDocument();
+    expect(screen.getByTestId("editor-content")).toBeInTheDocument();
   });
 
   it("isBeingEdited が true の場合、SectionLockBadge が表示される", () => {


### PR DESCRIPTION
ログインしていなくてもUIをなるべく揃えるようにした
<img width="1242" height="879" alt="Screenshot 2026-02-22 at 10 37 13" src="https://github.com/user-attachments/assets/48691d7c-6f80-470b-b61e-458ae33ab9df" />
